### PR TITLE
Mailerq Rest provider timeout set to 5 seconds, updated smtp exception

### DIFF
--- a/src/Client/CurlHttpClient.php
+++ b/src/Client/CurlHttpClient.php
@@ -4,6 +4,7 @@ namespace G4\Mailer\Client;
 
 class CurlHttpClient
 {
+    const CLIENT_TIMEOUT = 5;
     /**
      * @var resource
      */
@@ -29,6 +30,7 @@ class CurlHttpClient
             CURLOPT_RETURNTRANSFER => true,
             CURLINFO_HEADER_OUT    => true,
             CURLOPT_POST           => true,
+            CURLOPT_TIMEOUT        => self::CLIENT_TIMEOUT,
             CURLOPT_POSTFIELDS     => json_encode($params),
             CURLOPT_HTTPHEADER     => $headers,
         ]);

--- a/src/Transport/Smtp/Smtp.php
+++ b/src/Transport/Smtp/Smtp.php
@@ -24,7 +24,7 @@ class Smtp implements TransportInterface
 
         try {
             $transport->send(ZendMessageFacade::convert($message));
-        } catch (\Zend\Mail\Transport\Exception\RuntimeException $e) {
+        } catch (\Zend\Mail\Exception\RuntimeException $e) {
             throw new SmtpEmailNotSentException($e->getMessage(), $e->getCode());
         }
     }


### PR DESCRIPTION
Mailerq timeout set to 5 seconds and smtp exception is updated to  'Zend\Mail\Exception\RuntimeException'